### PR TITLE
Add fonts folder to deployed files.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
       ],
       "files": [
         "css/bootstrap.min.css",
-        "css/bootstrap-theme.min.css"
+        "css/bootstrap-theme.min.css",
+        "fonts/*"
       ],
       "shim": {
         "deps": ["bootstrap"]


### PR DESCRIPTION
The font files need to be deployed to components/bootstrap-default/fonts in order for them to be found when using &lt;link href="/components/require.css" rel="stylesheet" /&gt;. This change will make that happen.
