### PR TITLE
Depend on `components-bootstrap` ~3.3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "components-bootstrap": "~3.2.0"
+    "components-bootstrap": "~3.3.0"
   },
   "main": [
     "css/bootstrap.css",


### PR DESCRIPTION
No reason to rely on previous version of bootstrap, right?
